### PR TITLE
Allow custom endpoint for compatible services

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -118,10 +118,13 @@ fn args() -> ArgMatches<'static> {
 }
 
 fn main() {
-    let aws_region = env::var("AWS_REGION")
-        .map(|v| v.parse())
-        .unwrap_or(Ok(Region::ApNortheast1))
-        .expect("failed to parse AWS_REGION");
+    let aws_region = if let Ok(endpoint) = env::var("S3_ENDPOINT") {
+        let region = Region::Custom { name: "ap-northeast-1".to_owned(), endpoint: endpoint.to_owned() };
+        println!("picked up non-standard endpoint {:?} from S3_ENDPOINT env. variable", region);
+        region
+    } else {
+        Region::ApNortheast1
+    };
 
     let matches = args();
 


### PR DESCRIPTION
Our use cases are for S3 compatible on-prem services such as Ceph, Ozone or whatever. The snippet is from rutoso ( https://github.com/rusoto/rusoto/commit/e3189b6b811237cd07be45712f0e20d4e05bfe03#diff-6ab2de9b234ff9b24d3a4475a71641cb45da7d3ebca74e774c77e22242b1b4fdR33-R39 ).